### PR TITLE
Tested Updates

### DIFF
--- a/PidController/PidController/PidController.cs
+++ b/PidController/PidController/PidController.cs
@@ -35,17 +35,17 @@ namespace PidController
             float error = SetPoint - ProcessVariable;
 
             // integral term calculation
-            IntegralTerm += (GainIntegral * error * (float)timeSinceLastUpdate.TotalMilliseconds);
+            IntegralTerm += (GainIntegral * error * (float)timeSinceLastUpdate.TotalSeconds);
             IntegralTerm = Clamp(IntegralTerm);
 
             // derivative term calculation
             float dInput = processVariable - ProcessVariableLast;
-            float derivativeTerm = GainDerivative * (dInput / (float)timeSinceLastUpdate.TotalMilliseconds);
+            float derivativeTerm = GainDerivative * (dInput / (float)timeSinceLastUpdate.TotalSeconds);
 
             // proportional term calcullation
             float proportionalTerm = GainProportional * error;
 
-            float output = proportionalTerm + IntegralTerm + derivativeTerm;
+            float output = proportionalTerm + IntegralTerm - derivativeTerm;
 
             output = Clamp(output);
 

--- a/PidController/PidController/PidController.cs
+++ b/PidController/PidController/PidController.cs
@@ -13,9 +13,9 @@ namespace PidController
     /// <see cref="https://en.wikipedia.org/wiki/PID_controller"/>
     public sealed class PidController
     {
-        private float processVariable = 0.0f;
+        private double processVariable = 0;
 
-        public PidController(float GainProportional, float GainIntegral, float GainDerivative, float OutputMax, float OutputMin)
+        public PidController(double GainProportional, double GainIntegral, double GainDerivative, double OutputMax, double OutputMin)
         {
             this.GainDerivative = GainDerivative;
             this.GainIntegral = GainIntegral;
@@ -30,22 +30,22 @@ namespace PidController
         /// <param name="timeSinceLastUpdate">timespan of the elapsed time
         /// since the previous time that ControlVariable was called</param>
         /// <returns>Value of the variable that needs to be controlled</returns>
-        public float ControlVariable(TimeSpan timeSinceLastUpdate)
+        public double ControlVariable(TimeSpan timeSinceLastUpdate)
         {
-            float error = SetPoint - ProcessVariable;
+            double error = SetPoint - ProcessVariable;
 
             // integral term calculation
-            IntegralTerm += (GainIntegral * error * (float)timeSinceLastUpdate.TotalSeconds);
+            IntegralTerm += (GainIntegral * error * timeSinceLastUpdate.TotalSeconds);
             IntegralTerm = Clamp(IntegralTerm);
 
             // derivative term calculation
-            float dInput = processVariable - ProcessVariableLast;
-            float derivativeTerm = GainDerivative * (dInput / (float)timeSinceLastUpdate.TotalSeconds);
+            double dInput = processVariable - ProcessVariableLast;
+            double derivativeTerm = GainDerivative * (dInput / timeSinceLastUpdate.TotalSeconds);
 
             // proportional term calcullation
-            float proportionalTerm = GainProportional * error;
+            double proportionalTerm = GainProportional * error;
 
-            float output = proportionalTerm + IntegralTerm - derivativeTerm;
+            double output = proportionalTerm + IntegralTerm - derivativeTerm;
 
             output = Clamp(output);
 
@@ -56,13 +56,13 @@ namespace PidController
         /// The derivative term is proportional to the rate of
         /// change of the error
         /// </summary>
-        public float GainDerivative { get; set; } = 0;
+        public double GainDerivative { get; set; } = 0;
 
         /// <summary>
         /// The integral term is proportional to both the magnitude
         /// of the error and the duration of the error
         /// </summary>
-        public float GainIntegral { get; set; } = 0;
+        public double GainIntegral { get; set; } = 0;
 
         /// <summary>
         /// The proportional term produces an output value that
@@ -72,17 +72,17 @@ namespace PidController
         /// Tuning theory and industrial practice indicate that the
         /// proportional term should contribute the bulk of the output change.
         /// </remarks>
-        public float GainProportional { get; set; } = 0;
+        public double GainProportional { get; set; } = 0;
 
         /// <summary>
         /// The max output value the control device can accept.
         /// </summary>
-        public float OutputMax { get; private set; } = 0;
+        public double OutputMax { get; private set; } = 0;
 
         /// <summary>
         /// The minimum ouput value the control device can accept.
         /// </summary>
-        public float OutputMin { get; private set; } = 0;
+        public double OutputMin { get; private set; } = 0;
 
         /// <summary>
         /// Adjustment made by considering the accumulated error over time
@@ -91,13 +91,13 @@ namespace PidController
         /// An alternative formulation of the integral action, is the
         /// proportional-summation-difference used in discrete-time systems
         /// </remarks>
-        public float IntegralTerm { get; private set; } = 0;
+        public double IntegralTerm { get; private set; } = 0;
 
 
         /// <summary>
         /// The current value
         /// </summary>
-        public float ProcessVariable
+        public double ProcessVariable
         {
             get { return processVariable; }
             set
@@ -110,12 +110,12 @@ namespace PidController
         /// <summary>
         /// The last reported value (used to calculate the rate of change)
         /// </summary>
-        public float ProcessVariableLast { get; private set; } = 0;
+        public double ProcessVariableLast { get; private set; } = 0;
 
         /// <summary>
         /// The desired value
         /// </summary>
-        public float SetPoint { get; set; } = 0;
+        public double SetPoint { get; set; } = 0;
 
         /// <summary>
         /// Limit a variable to the set OutputMax and OutputMin properties
@@ -126,7 +126,7 @@ namespace PidController
         /// <remarks>
         /// Inspiration from http://stackoverflow.com/questions/3176602/how-to-force-a-number-to-be-in-a-range-in-c
         /// </remarks>
-        private float Clamp(float variableToClamp)
+        private double Clamp(double variableToClamp)
         {
             if (variableToClamp <= OutputMin) { return OutputMin; }
             if (variableToClamp >= OutputMax) { return OutputMax; }

--- a/README.md
+++ b/README.md
@@ -40,21 +40,22 @@ PidController controller = new PidController(float GainProportional, float GainI
   * ```OutputMin``` - The minimum value the ```ControlVariable``` property can return
 
 ## Properties
-| Property            | Type        | Access  | Description                                                     |
-|---------------------|-------------|---------|-----------------------------------------------------------------|
-| GainProportional    | ```float``` | get/set | The proportional gain in the feedback loop                      |
-| GainIntegral        | ```float``` | get/set | The integral gain in the feedback loop                          |
-| GainDerivative      | ```float``` | get/set | The derivative gain in the feedback loop                        |
-| OutputMax           | ```float``` | get     | The maximum value the ```ControlVariable``` property can return |
-| OutputMin           | ```float``` | get     | The minimum value the ```ControlVariable``` property can return |
-| IntegralTerm        | ```float``` | get     | Tracks the accumulated error in the control loop                |
-| ProcessVariable     | ```float``` | get/set | Current value of the process under control                      |
-| ProcessVariableLast | ```float``` | get     | Last stored value of the process under control                  |
-| SetPoint            | ```float``` | get/set | The desired value of the process under control                  |
+| Property            | Type         | Access  | Description                                                     |
+|---------------------|--------------|---------|-----------------------------------------------------------------|
+| GainProportional    | ```double``` | get/set | The proportional gain in the feedback loop                      |
+| GainIntegral        | ```double``` | get/set | The integral gain in the feedback loop                          |
+| GainDerivative      | ```double``` | get/set | The derivative gain in the feedback loop                        |
+| OutputMax           | ```double``` | get     | The maximum value the ```ControlVariable``` function can return |
+| OutputMin           | ```double``` | get     | The minimum value the ```ControlVariable``` function can return |
+| IntegralTerm        | ```double``` | get     | Tracks the accumulated error in the control loop                |
+| ProcessVariable     | ```double``` | get/set | Current value of the process under control                      |
+| ProcessVariableLast | ```double``` | get     | Last stored value of the process under control                  |
+| SetPoint            | ```double``` | get/set | The desired value of the process under control                  |
 
 ## Functions
-| Property            | Type        | Access  | Description                                                     |
-| ControlVariable(```TimeSpan timeSinceLastUpdate```)     | ```float``` | The control variable that drives the process under control, depending on the amount of time that passed since the last time it was called      |
+| Function        | Return Type  | Description  |
+|-----------------|--------------|-----------------------|
+| ControlVariable(```TimeSpan timeSinceLastUpdate```)     | ```double``` | The control variable that drives the process under control, depending on the amount of time that passed since the last time it was called      |
 
 ## Tuning
 There are lots of resources online for learning how to tune a PID controller. For a quick primer see the Wikipedia entry on [manual tuning](https://en.wikipedia.org/wiki/PID_controller#Manual_tuning).


### PR DESCRIPTION
This PR has the following changes
1. I've updated the time units to seconds.
2. Changed the types used to doubles.
3. Most importantly I changed the sign on the derivative term to a subtraction symbol.

I understand the symbol was previously changed to an addition symbol but this was in fact due to a simple misunderstanding. This controller is implemented using the derivative of the process value:
![image](https://cloud.githubusercontent.com/assets/8797401/23343051/f34d9cb0-fc32-11e6-8fed-f9781431635e.png)
and not using the derivative of the error:
![image](https://cloud.githubusercontent.com/assets/8797401/23343057/26cc3920-fc33-11e6-8137-26f3973da82b.png)
Therefor the derivative term should either be negative as previously it was or subtracted in the output. Either is fine, I implemented the latter.

For more details, see my comments in issue #9 

-Tommallama


